### PR TITLE
Hide in-route feedback button

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -330,6 +330,9 @@ extension DefaultMapsViewController: StateListener {
         )
         navigationViewController?.modalPresentationStyle = .fullScreen
         navigationViewController?.delegate = self
+        /// Disable "Report Problem" sheet that shows while navigating.
+        navigationViewController?.showsReportFeedback = false
+        navigationViewController?.showsEndOfRouteFeedback = true
 
         sheetManager.dismissAllSheets(animated: false) {
           self.present(self.navigationViewController!, animated: true, completion: nil)
@@ -644,6 +647,13 @@ extension DefaultMapsViewController: NavigationViewControllerDelegate {
   ) {
     self.navigationViewController = nil
     stateManager.state = .initial
+  }
+
+  func navigationViewController(
+    _ navigationViewController: NavigationViewController,
+    didSubmitArrivalFeedback feedback: EndOfRouteFeedback
+  ) {
+    // TODO: (@mattrobmattrob) Upload this feedback
   }
 }
 


### PR DESCRIPTION
Hide the feedback button during live routing but retain the “End of Navigation” feedback mechanism.

|Before|Before - Feedback|After|
|---|---|---|
|![Simulator Screenshot - iPhone 15 - 2023-12-08 at 10 30 33](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/a3ae7a2e-1f6f-44fb-aee7-15b3e63a1df3)|![Simulator Screenshot - iPhone 15 - 2023-12-08 at 10 21 32](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/757f5f4f-b4ff-445b-b280-3d581a5076e7)|![Simulator Screenshot - iPhone 15 - 2023-12-08 at 10 30 01](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/1072a338-33a5-463e-9c61-cc82af59be9f)|
