### PR TITLE
Address visual feedback for beta testing

### DIFF
--- a/bikestreets-ios.xcodeproj/project.pbxproj
+++ b/bikestreets-ios.xcodeproj/project.pbxproj
@@ -94,7 +94,7 @@
 		3550D96D2A9D002E00C70EE5 /* SheetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetManager.swift; sourceTree = "<group>"; };
 		3550D96F2A9D351300C70EE5 /* CompassManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassManager.swift; sourceTree = "<group>"; };
 		35A2F0BE2A4F7957002BF520 /* MapsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapsViewController.swift; sourceTree = "<group>"; };
-		35A482932A37B1E4001035BB /* BikeStreets.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BikeStreets.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		35A482932A37B1E4001035BB /* VAMOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VAMOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		35A4829A2A37B1E6001035BB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		35A482AF2A37C02E001035BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		35AEFC112B22D92000234813 /* CLLocationManager+AuthorizationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLLocationManager+AuthorizationState.swift"; sourceTree = "<group>"; };
@@ -270,7 +270,7 @@
 		35A482942A37B1E4001035BB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				35A482932A37B1E4001035BB /* BikeStreets.app */,
+				35A482932A37B1E4001035BB /* VAMOS.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -323,9 +323,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		35A482922A37B1E4001035BB /* BikeStreets */ = {
+		35A482922A37B1E4001035BB /* VAMOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 35A482A12A37B1E6001035BB /* Build configuration list for PBXNativeTarget "BikeStreets" */;
+			buildConfigurationList = 35A482A12A37B1E6001035BB /* Build configuration list for PBXNativeTarget "VAMOS" */;
 			buildPhases = (
 				35A4828F2A37B1E4001035BB /* Sources */,
 				35A482902A37B1E4001035BB /* Frameworks */,
@@ -335,7 +335,7 @@
 			);
 			dependencies = (
 			);
-			name = BikeStreets;
+			name = VAMOS;
 			packageProductDependencies = (
 				35A482A52A37B279001035BB /* MapboxMaps */,
 				35A482A82A37BD4C001035BB /* MapboxDirections */,
@@ -348,7 +348,7 @@
 				359CB5D02AD9BC53004560A2 /* MapboxNavigation */,
 			);
 			productName = MapboxTester;
-			productReference = 35A482932A37B1E4001035BB /* BikeStreets.app */;
+			productReference = 35A482932A37B1E4001035BB /* VAMOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -386,7 +386,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				35A482922A37B1E4001035BB /* BikeStreets */,
+				35A482922A37B1E4001035BB /* VAMOS */,
 			);
 		};
 /* End PBXProject section */
@@ -578,9 +578,9 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "bikestreets-ios/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Bike Streets";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Your current location will be displayed on the map and used for directions and estimated travel times.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Your current location will be displayed on the map and used for directions and estimated travel times.";
+				INFOPLIST_KEY_CFBundleDisplayName = VAMOS;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "VAMOS provides low-stress bike routes to any destination in Denver. You must enable permissions to use the app.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "VAMOS provides low-stress bike routes to any destination in Denver. You must enable permissions to use the app.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -608,9 +608,9 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "bikestreets-ios/Info.plist";
-				INFOPLIST_KEY_CFBundleDisplayName = "Bike Streets";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "Your current location will be displayed on the map and used for directions and estimated travel times.";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Your current location will be displayed on the map and used for directions and estimated travel times.";
+				INFOPLIST_KEY_CFBundleDisplayName = VAMOS;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "VAMOS provides low-stress bike routes to any destination in Denver. You must enable permissions to use the app.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "VAMOS provides low-stress bike routes to any destination in Denver. You must enable permissions to use the app.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -639,7 +639,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		35A482A12A37B1E6001035BB /* Build configuration list for PBXNativeTarget "BikeStreets" */ = {
+		35A482A12A37B1E6001035BB /* Build configuration list for PBXNativeTarget "VAMOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				35A482A22A37B1E6001035BB /* Debug */,

--- a/bikestreets-ios.xcodeproj/xcshareddata/xcschemes/BikeStreets.xcscheme
+++ b/bikestreets-ios.xcodeproj/xcshareddata/xcschemes/BikeStreets.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "35A482922A37B1E4001035BB"
-               BuildableName = "BikeStreets.app"
-               BlueprintName = "BikeStreets"
+               BuildableName = "VAMOS.app"
+               BlueprintName = "VAMOS"
                ReferencedContainer = "container:bikestreets-ios.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -44,8 +44,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "35A482922A37B1E4001035BB"
-            BuildableName = "BikeStreets.app"
-            BlueprintName = "BikeStreets"
+            BuildableName = "VAMOS.app"
+            BlueprintName = "VAMOS"
             ReferencedContainer = "container:bikestreets-ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -61,8 +61,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "35A482922A37B1E4001035BB"
-            BuildableName = "BikeStreets.app"
-            BlueprintName = "BikeStreets"
+            BuildableName = "VAMOS.app"
+            BlueprintName = "VAMOS"
             ReferencedContainer = "container:bikestreets-ios.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/bikestreets-ios/Extensions/CLLocationManager+AuthorizationState.swift
+++ b/bikestreets-ios/Extensions/CLLocationManager+AuthorizationState.swift
@@ -9,6 +9,7 @@ import Foundation
 import CoreLocation
 
 extension CLLocationManager {
+  /// Should the system request location permissions?
   var shouldPresentShareLocationView: Bool {
     switch authorizationStatus {
     case .notDetermined, .restricted, .denied:

--- a/bikestreets-ios/Info.plist
+++ b/bikestreets-ios/Info.plist
@@ -2,12 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
-	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>MBXAccessToken</key>
 	<string>pk.eyJ1IjoibWtiaXRidWNrZXQiLCJhIjoiY2swNWNzNGxqMDAwNDNjbzhrdmxnbTdiNSJ9.F3s1ErkGUpi-xnLp9jOWYw</string>
+	<key>MGLMapboxMetricsEnabledSettingShownInApp</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/bikestreets-ios/Map/Controls/MapControlView.swift
+++ b/bikestreets-ios/Map/Controls/MapControlView.swift
@@ -48,7 +48,6 @@ private final class MapControlButton: UIButton {
 final class MapControlView: UIStackView {
   private let mapCameraManager: MapCameraManager
 
-  private let infoButton = MapControlButton()
   private let locationButton = MapControlButton()
 
   init(mapCameraManager: MapCameraManager) {
@@ -66,14 +65,7 @@ final class MapControlView: UIStackView {
     axis = .vertical
     spacing = 8
 
-    [
-      infoButton,
-      locationButton
-    ].forEach {
-      addArrangedSubview($0)
-    }
-
-    infoButton.imageSystemName = "info"
+    addArrangedSubview(locationButton)
 
     locationButton.addTarget(self, action: #selector(fromIdle), for: .touchUpInside)
     syncLocationButtonImage()

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -537,7 +537,7 @@ extension DefaultMapsViewController: MapCameraStateListener {
     case .showDenver:
       let cameraOptions = CameraOptions(
         center: .denver,
-        zoom: 15.5
+        zoom: MapZoomOptions.defaultZoomLevel
       )
       mapView.mapboxMap.setCamera(to: cameraOptions)
 
@@ -547,6 +547,7 @@ extension DefaultMapsViewController: MapCameraStateListener {
       newState = mapView.viewport.makeFollowPuckViewportState(
         options: FollowPuckViewportStateOptions(
           padding: UIEdgeInsets(top: 200, left: 0, bottom: bottomInset, right: 0),
+          zoom: MapZoomOptions.defaultZoomLevel,
           // Intentionally avoid bearing sync in search mode.
           bearing: .none,
           pitch: 0

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -227,9 +227,9 @@ extension DefaultMapsViewController: StateListener {
     case .initialTerms:
       let alertViewController = CustomAlertViewController(
         configuration: .init(
-          body: "You must accept the VAMOS Routes terms of use before you use the app.",
+          body: "You must accept the terms of use before you use the app.",
           buttons: [
-            .openURL(text: "Full Terms", url: URL(string: "https://www.bikestreets.com/terms")!),
+            .openURL(text: "View Terms", url: URL(string: "https://www.bikestreets.com/terms")!),
             .accept(text: "Accept Terms", callback: { [weak self] presentedViewController in
               guard let self else { return }
               presentedViewController.dismiss(animated: true)

--- a/bikestreets-ios/Map/MapsViewController.swift
+++ b/bikestreets-ios/Map/MapsViewController.swift
@@ -239,9 +239,16 @@ extension PointAnnotation {
   }
 }
 
-// MARK: -
+// MARK: - Locations
 
 extension CLLocationCoordinate2D {
-  static let sanFrancisco = CLLocationCoordinate2D(latitude: 37.7911551, longitude: -122.3966103)
-  static let denver = CLLocationCoordinate2D(latitude: 39.753580116073685, longitude: -105.04056378182935)
+  /// Union Station
+  static let denver = CLLocationCoordinate2D(
+    latitude: 39.75318695812184,
+    longitude: -105.00017364813098
+  )
+}
+
+struct MapZoomOptions {
+  static let defaultZoomLevel = 14.5
 }

--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -52,7 +52,7 @@ final class DirectionPreviewViewController: UIViewController {
 
     let titleLabel = UILabel()
     titleLabel.text = "Directions"
-    titleLabel.font = .preferredFont(forTextStyle: .largeTitle, weight: .bold)
+    titleLabel.font = .preferredFont(forTextStyle: .title1, weight: .bold)
 
     let titleContainer = UIView()
     titleContainer.addSubview(titleLabel)
@@ -63,10 +63,6 @@ final class DirectionPreviewViewController: UIViewController {
     placesStackView.layer.cornerRadius = 16
     placesStackView.clipsToBounds = true
     placesStackView.backgroundColor = .tertiarySystemBackground
-
-    let routesLabel = UILabel()
-    routesLabel.text = "Routes"
-    routesLabel.font = .preferredFont(forTextStyle: .title2, weight: .bold)
 
     let possibleRoutesView = PossibleRoutesView(routes: routes)
     possibleRoutesView.delegate = self

--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -74,7 +74,6 @@ final class DirectionPreviewViewController: UIViewController {
     let stackView = UIStackView(arrangedSubviews: [
       titleContainer,
       placesStackView,
-      routesLabel,
       possibleRoutesView,
       spacerView
     ])
@@ -85,7 +84,6 @@ final class DirectionPreviewViewController: UIViewController {
 
     [
       titleLabel,
-      routesLabel,
       spacerView,
       stackView,
     ].disableTranslatesAutoresizingMaskIntoConstraints()

--- a/bikestreets-ios/Search/SearchConfiguration.swift
+++ b/bikestreets-ios/Search/SearchConfiguration.swift
@@ -16,8 +16,8 @@ enum SearchConfiguration {
 
   var searchBarPlaceholder: String {
     switch self {
-    case .initialDestination, .newDestination: return "Set Destination"
-    case .newOrigin: return "Set Starting Point"
+    case .initialDestination, .newDestination: return "Search for a destination"
+    case .newOrigin: return "Search for a starting point"
     }
   }
 }

--- a/bikestreets-ios/Search/SearchViewController.swift
+++ b/bikestreets-ios/Search/SearchViewController.swift
@@ -38,10 +38,6 @@ final class SearchViewController: UIViewController {
 
     let insetView = UIView()
 
-    let vamosLabel = UILabel()
-    vamosLabel.text = "Find a route with VAMOS"
-    vamosLabel.font = .preferredFont(forTextStyle: .title1)
-
     let stackView = UIStackView()
     stackView.axis = .vertical
     stackView.spacing = 8
@@ -59,13 +55,11 @@ final class SearchViewController: UIViewController {
 
     view.addSubviews(
       insetView,
-      vamosLabel,
       stackView
     )
 
     [
       insetView,
-      vamosLabel,
       stackView,
       searchBarHolder
     ].disableTranslatesAutoresizingMaskIntoConstraints()
@@ -76,11 +70,7 @@ final class SearchViewController: UIViewController {
       insetView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: -16),
       insetView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
 
-      vamosLabel.topAnchor.constraint(equalTo: insetView.topAnchor),
-      vamosLabel.leftAnchor.constraint(equalTo: insetView.leftAnchor),
-      vamosLabel.rightAnchor.constraint(equalTo: insetView.rightAnchor),
-
-      vamosLabel.bottomAnchor.constraint(equalTo: stackView.topAnchor),
+      insetView.topAnchor.constraint(equalTo: stackView.topAnchor),
       view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
       view.leftAnchor.constraint(equalTo: stackView.leftAnchor),
       view.rightAnchor.constraint(equalTo: stackView.rightAnchor),

--- a/bikestreets-ios/Search/Views/PossibleRoutesView.swift
+++ b/bikestreets-ios/Search/Views/PossibleRoutesView.swift
@@ -53,20 +53,12 @@ final class PossibleRoutesView: UIStackView {
     }
 
     for (index, route) in routes.enumerated() {
-      let titleLabel = UILabel()
-      titleLabel.text = "Route \(index + 1)"
-      titleLabel.font = .preferredFont(forTextStyle: .body, weight: .bold)
-
       let distanceLabel = UILabel()
       distanceLabel.text = distanceString(for: route.distance)
       distanceLabel.font = .preferredFont(forTextStyle: .callout)
 
       let leftInsetView = UIView()
-
-      let labelStack = UIStackView(arrangedSubviews: [titleLabel, distanceLabel])
-      labelStack.axis = .vertical
-      labelStack.spacing = 4
-
+      
       let spacerView = UIView()
 
       let button = UIButton(type: .roundedRect)
@@ -83,7 +75,6 @@ final class PossibleRoutesView: UIStackView {
       let rightInsetView = UIView()
 
       [
-        titleLabel,
         distanceLabel,
         leftInsetView,
         spacerView,
@@ -102,7 +93,7 @@ final class PossibleRoutesView: UIStackView {
 
       let routeStack = UIStackView(arrangedSubviews: [
         leftInsetView,
-        labelStack,
+        distanceLabel,
         spacerView,
         button,
         rightInsetView


### PR DESCRIPTION
- Rename app VAMOS
- /accept terms
  - “You must accept the terms of use before you use the app.”
  - Change “Full Terms” to “View Terms”
- Default iOS location sharing (location permission as per Matthew) sheet
  - Change “Allow Bike Streets to use your location” to “Allow VAMOS…”
  - Change “Your current location will be used for…” to “VAMOS provides low-stress bike routes to any destination in Denver. You must enable permissions to use the app.”
- /search (aka /initial per Matthew)
  - Cut “Find a route with VAMOS” header
  - Search field label “Set Destination” >> “Search for a destination”
  - Remove “i” button
  - Zoom out farther on default /initial so people can see the map in case they are in a location where there’s no immediately adjacent route
- /plan (/route map per Matthew)
  - Make “Directions” header smaller
  - Remove “Routes” header
  - Remove “Route 1” subheader
  - Remove “i” button
