### PR TITLE
Render current route below Vamos network

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -158,19 +158,47 @@ final class DefaultMapsViewController: MapsViewController {
     selectedRoute: MapboxDirections.Route,
     potentialRoutes: [MapboxDirections.Route]
   ) {
-    let selectedRouteAnnotations: [PolylineAnnotation] = selectedRoute.legs.flatMap { leg -> [MapboxDirections.RouteStep] in
-      leg.steps
-    }.map { step -> PolylineAnnotation in
-      return .activeRouteAnnotation(
-        coordinates: step.shape?.coordinates ?? [],
-        isRouting: isRouting,
-        isHikeABike: step.transportType == .walking
-      )
+    let geoJSONDataSourceIdentifier = "current-route"
+
+    func removeLayer(withId identifier: String) {
+      if mapView.mapboxMap.style.layerExists(withId: identifier) {
+        try! mapView.mapboxMap.style.removeLayer(withId: identifier)
+        try! mapView.mapboxMap.style.removeSource(withId: identifier)
+      }
     }
 
-    polylineAnnotationManager.annotations = selectedRouteAnnotations + potentialRoutes.map {
-      .potentialRouteAnnotation(coordinates: $0.shape?.coordinates ?? [])
+    guard let routeGeometry = selectedRoute.shape?.geometry else {
+      removeLayer(withId: geoJSONDataSourceIdentifier)
+      return
     }
+
+    // Create a GeoJSON data source.
+    var geoJSONSource = GeoJSONSource()
+    geoJSONSource.data = .geometry(routeGeometry)
+
+    let lineLayer = BikeStreetsStyles.style(
+      forLayer: geoJSONDataSourceIdentifier,
+      source: geoJSONDataSourceIdentifier,
+      lineColor: StyleColor(.vamosYellow),
+      lineWidth: .expression(
+        Exp(.interpolate) {
+          Exp(.linear)
+          Exp(.zoom)
+          14
+          6
+          18
+          12
+        }
+      )
+    )
+
+    // Add the source and style layer to the map style.
+    removeLayer(withId: geoJSONDataSourceIdentifier)
+    try! mapView.mapboxMap.style.addSource(geoJSONSource, id: geoJSONDataSourceIdentifier)
+    try! mapView.mapboxMap.style.addLayer(
+      lineLayer,
+      layerPosition: .at(BikeStreetsMapOrdering.vamosNetwork - 1)
+    )
   }
 
   // MARK: - State Handling

--- a/bikestreets-ios/Map/MapsViewController.swift
+++ b/bikestreets-ios/Map/MapsViewController.swift
@@ -9,9 +9,7 @@ import MapboxMaps
 import MapboxSearch
 import MapKit
 
-protocol ExampleController: UIViewController {}
-
-class MapsViewController: UIViewController, ExampleController {
+class MapsViewController: UIViewController {
   let mapView = MapView(frame: .zero)
   lazy var polylineAnnotationManager = mapView.annotations.makePolylineAnnotationManager()
   lazy var annotationsManager = mapView.annotations.makePointAnnotationManager()
@@ -51,10 +49,6 @@ class MapsViewController: UIViewController, ExampleController {
 
     // Show Mapbox styles
     updateMapStyle()
-    DispatchQueue.main.async {
-      // Initially, always load the BikeStreets map layers.
-      self.loadMapFromShippedResources()
-    }
   }
 
   // MARK: -- Annotations
@@ -141,7 +135,7 @@ extension MapsViewController {
     if traitCollection.userInterfaceStyle == .dark {
       style = .dark
     } else {
-      style = .streets
+      style = .vamosStreets
     }
 
     // Only update anything if style is different.
@@ -209,13 +203,18 @@ extension MapsViewController {
       var geoJSONSource = GeoJSONSource()
       geoJSONSource.data = .featureCollection(featureCollection)
       geoJSONSource.lineMetrics = true // MUST be `true` in order to use `lineGradient` expression
-      
+
       // Create a line layer
-      let lineLayer = BikeStreetsStyles.style(forLayer: geoJSONDataSourceIdentifier, source: geoJSONDataSourceIdentifier)
-      
+      let lineColor = BikeStreetsStyles.mapLayerColor(forLayer: geoJSONDataSourceIdentifier)
+      let lineLayer = BikeStreetsStyles.style(
+        forLayer: geoJSONDataSourceIdentifier,
+        source: geoJSONDataSourceIdentifier,
+        lineColor: lineColor
+      )
+
       // Add the source and style layer to the map style.
       try! mapView.mapboxMap.style.addSource(geoJSONSource, id: geoJSONDataSourceIdentifier)
-      try! mapView.mapboxMap.style.addLayer(lineLayer, layerPosition: nil)
+      try! mapView.mapboxMap.style.addLayer(lineLayer, layerPosition: .at(BikeStreetsMapOrdering.vamosNetwork))
     }
   }
 }

--- a/bikestreets-ios/Styles/BikeStreetsColors.swift
+++ b/bikestreets-ios/Styles/BikeStreetsColors.swift
@@ -11,5 +11,11 @@ import UIKit
 extension UIColor {
   static let vamosBlue = UIColor(red: 53.0 / 255.0, green: 90.0 / 255.0, blue: 168.0 / 255.0, alpha: 1)
   static let vamosPurple = UIColor(red: 151.0 / 255.0, green: 27.0 / 255.0, blue: 138.0 / 255.0, alpha: 1)
+  static let vamosYellow = UIColor(
+    red: 254.0 / 255.0,
+    green: 205.0 / 255.0,
+    blue: 59.0 / 255.0,
+    alpha: 1
+  )
 }
 

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -9,6 +9,21 @@ import Foundation
 import MapboxMaps
 import UIKit
 
+/// Used for adding layers above/below the Vamos network on the map.
+struct BikeStreetsMapOrdering {
+  static let vamosNetwork: Int = 100
+}
+
+// MARK: - Map Styles
+
+extension StyleURI {
+  /// Avi's custom map style designed to minimize highway prevalence.
+  /// This style started out as `.streets` with customizations.
+  static let vamosStreets = StyleURI(
+    rawValue: "mapbox://styles/mkbitbucket/clqgwgexa007s01rjhxpwcpaw"
+  )!
+}
+
 // MARK: -
 
 extension UIColor {
@@ -95,7 +110,12 @@ enum BikeStreetsStyles {
   )
 
   /// From: https://docs.mapbox.com/ios/maps/examples/line-gradient/
-  static func style(forLayer layerName: String, source: String) -> LineLayer {
+  static func style(
+    forLayer layerName: String,
+    source: String,
+    lineColor: StyleColor,
+    lineWidth: Value<Double> = BikeStreetsStyles.lineWidth
+  ) -> LineLayer {
     var lineLayer = LineLayer(id: layerName /* "line-layer" */ )
     lineLayer.filter = Exp(.eq) {
       "$type"
@@ -108,9 +128,6 @@ enum BikeStreetsStyles {
     // Set the line join and cap to a rounded end.
     lineLayer.lineJoin = .constant(.round)
     lineLayer.lineCap = .constant(.round)
-
-    // Get the line color for this layer
-    let lineColor = mapLayerColor(forLayer: layerName)
 
     lineLayer.lineColor = .constant(lineColor)
     lineLayer.lineWidth = lineWidth


### PR DESCRIPTION
- Update color of current route and render below the Vamos network.
- Update the light mode map style to Avi’s custom format.

|Far Out|Close Up|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2023-12-22 at 17 31 02](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/a05dc626-4342-4e44-9c2d-75fcc544fa4d)|![Simulator Screenshot - iPhone 15 - 2023-12-22 at 17 31 11](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/dd39fbf6-5405-414d-b1c6-0074a1bb316c)|