### PR TITLE
Add OSRM + Mapbox generated route visualization

### DIFF
--- a/bikestreets-ios.xcodeproj/project.pbxproj
+++ b/bikestreets-ios.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		35D13F762AE7FF3400A31CB0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 35D13F752AE7FF3400A31CB0 /* Settings.bundle */; };
 		35F8C19A2B238C34007AF870 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F8C1992B238C34007AF870 /* Bundle+AppVersion.swift */; };
 		35F8C19D2B2396B8007AF870 /* FeedbackEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F8C19C2B2396B8007AF870 /* FeedbackEmailViewController.swift */; };
+		35FE5FF62B486792002A4472 /* GlobalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FE5FF52B486792002A4472 /* GlobalSettings.swift */; };
 		9AA97B2D2AE87E9C00C59426 /* UIView+Subview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA97B2C2AE87E9C00C59426 /* UIView+Subview.swift */; };
 /* End PBXBuildFile section */
 
@@ -108,6 +109,7 @@
 		35F8C19C2B2396B8007AF870 /* FeedbackEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackEmailViewController.swift; sourceTree = "<group>"; };
 		35FE5FF32B485FE3002A4472 /* Washington Park - Denver, CO.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Washington Park - Denver, CO.gpx"; sourceTree = "<group>"; };
 		35FE5FF42B485FE3002A4472 /* Sloan's Neighborhood - Denver, CO.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Sloan's Neighborhood - Denver, CO.gpx"; sourceTree = "<group>"; };
+		35FE5FF52B486792002A4472 /* GlobalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSettings.swift; sourceTree = "<group>"; };
 		9AA97B2C2AE87E9C00C59426 /* UIView+Subview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Subview.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -195,6 +197,7 @@
 				35065CAE2A7D9B8300C7CCAF /* RouteRequester.swift */,
 				35065CC12A8043E900C7CCAF /* ScreenManager.swift */,
 				35065CAC2A7D9A8F00C7CCAF /* StateManager.swift */,
+				35FE5FF52B486792002A4472 /* GlobalSettings.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				3550D96B2A9CFBAC00C70EE5 /* MapControlView.swift in Sources */,
 				9AA97B2D2AE87E9C00C59426 /* UIView+Subview.swift in Sources */,
 				35065CBA2A803A4000C7CCAF /* UISheetPresentationController+Configuration.swift in Sources */,
+				35FE5FF62B486792002A4472 /* GlobalSettings.swift in Sources */,
 				35AEFC152B22DCC600234813 /* CustomAlertViewController.swift in Sources */,
 				35A2F0BF2A4F7957002BF520 /* MapsViewController.swift in Sources */,
 				35065CC22A8043E900C7CCAF /* ScreenManager.swift in Sources */,

--- a/bikestreets-ios/Managers/CompassManager.swift
+++ b/bikestreets-ios/Managers/CompassManager.swift
@@ -24,8 +24,8 @@ final class MapCameraManager {
     case followUserHeading
     case followUserHeadingIdle
     /// Not oriented to anything. User could be free-scrolling the map.
-    case showRoute(route: Route)
-    case showRouteIdle(route: Route)
+    case showRoute(route: CombinedRoute)
+    case showRouteIdle(route: CombinedRoute)
   }
 
   var state: State = .showDenver {

--- a/bikestreets-ios/Managers/GlobalSettings.swift
+++ b/bikestreets-ios/Managers/GlobalSettings.swift
@@ -1,0 +1,33 @@
+//
+//  GlobalSettings.swift
+//  VAMOS
+//
+//  Created by Matt Robinson on 1/5/24.
+//
+
+import Foundation
+
+struct GlobalSettings {
+
+  // MARK: -- Directions Preview
+
+  enum DirectionsPreviewConfiguration {
+    /// Show just the Mapbox Directions result on the directions preview screen.
+    case mapbox
+    /// Show both the OSRM and Mapbox result on the directions preview screen.
+    case combined
+  }
+
+  static let directionsPreviewConfiguration: DirectionsPreviewConfiguration = .combined
+
+  // MARK: -- Live Routing
+
+  enum LiveRoutingConfiguration {
+    /// Use Mapbox's built-in live navigation UI.
+    case mapbox
+    /// Use DIY BikeStreets navigation UI.
+    case custom
+  }
+
+  static let liveRoutingConfiguration: LiveRoutingConfiguration = .mapbox
+}

--- a/bikestreets-ios/Managers/RouteRequester.swift
+++ b/bikestreets-ios/Managers/RouteRequester.swift
@@ -12,6 +12,29 @@ import MapboxNavigation
 import MapboxDirections
 import SimplifySwift
 
+/// Combination of the generated OSRM and Mapbox routes.
+struct CombinedRoute {
+  let osrm: Route
+  let mapbox: Route
+}
+
+/// Representation of the route response from the BikeStreets internal OSRM API
+/// and the external Mapbox API.
+struct CombinedRouteResponse {
+  let osrm: RouteResponse
+  let mapbox: RouteResponse
+
+  /// An array of `Route` objects based on the choice ot use the OSRM or Mapbox backend.
+  public var routes: [Route]? {
+    switch GlobalSettings.liveRoutingConfiguration {
+    case .mapbox:
+      return mapbox.routes
+    case .custom:
+      return osrm.routes
+    }
+  }
+}
+
 final class RouteRequester {
   enum RequestError: Error {
     case emptyData
@@ -23,7 +46,7 @@ final class RouteRequester {
     startPoint: CLLocationCoordinate2D,
     destinationName: String,
     endPoint: CLLocationCoordinate2D,
-    completion: @escaping (Result<RouteResponse, Error>) -> Void
+    completion: @escaping (Result<CombinedRouteResponse, Error>) -> Void
   ) {
     // BIKESTREETS DIRECTIONS
 
@@ -84,12 +107,12 @@ final class RouteRequester {
           .credentials: Directions.shared.credentials,
         ]
 
-        let result = try decoder.decode(RouteResponse.self, from: data)
+        let osrmResponse = try decoder.decode(RouteResponse.self, from: data)
 
         // Request Mapbox route
         //
         // Copied from: https://docs.mapbox.com/ios/navigation/examples/custom-server/
-        let originalRouteCoordinates = result.routes?[0].shape?.coordinates ?? []
+        let originalRouteCoordinates = osrmResponse.routes?[0].shape?.coordinates ?? []
 
         var tolerance: Float = 0.00001
         var simplifiedRouteCoordinates = originalRouteCoordinates
@@ -129,9 +152,9 @@ final class RouteRequester {
           switch mapboxResult {
           case .failure(let error):
             print(error.localizedDescription)
-          case .success(let response):
+          case .success(let mapboxResponse):
             // Return parsed response
-            completion(.success(response))
+            completion(.success(.init(osrm: osrmResponse, mapbox: mapboxResponse)))
           }
         }
 

--- a/bikestreets-ios/Managers/StateManager.swift
+++ b/bikestreets-ios/Managers/StateManager.swift
@@ -49,14 +49,14 @@ final class StateManager {
 
   struct DirectionsPreview {
     let request: RouteRequest
-    let response: RouteResponse
-    let selectedRoute: Route
+    let response: CombinedRouteResponse
+    let selectedRoute: CombinedRoute
   }
 
   struct Routing {
     let request: RouteRequest
-    let response: RouteResponse
-    let selectedRoute: Route
+    let response: CombinedRouteResponse
+    let selectedRoute: CombinedRoute
   }
 
   enum State {

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -16,12 +16,6 @@ import SwiftUI
 import UIKit
 
 final class DefaultMapsViewController: MapsViewController {
-  private enum LiveRoutingConfiguration {
-    case mapbox
-    case custom
-  }
-  private let liveRoutingConfiguration: LiveRoutingConfiguration = .mapbox
-
   private let locationManager = CLLocationManager()
 
   private lazy var mapControlView: MapControlView = {
@@ -150,12 +144,9 @@ final class DefaultMapsViewController: MapsViewController {
   // MARK: - Map Movement
 
   // TODO: Make this smarter using approach from https://docs.mapbox.com/ios/maps/examples/line-gradient/
-  private func updateMapAnnotations(
-    isRouting: Bool,
-    selectedRoute: MapboxDirections.Route,
-    potentialRoutes: [MapboxDirections.Route]
-  ) {
+  private func updateMapAnnotations(combinedRoute: CombinedRoute) {
     let geoJSONDataSourceIdentifier = "current-route"
+    let geoJSONDataSourceIdentifierOSRM = "current-route-osrm"
 
     func removeLayer(withId identifier: String) {
       if mapView.mapboxMap.style.layerExists(withId: identifier) {
@@ -164,38 +155,68 @@ final class DefaultMapsViewController: MapsViewController {
       }
     }
 
-    guard let routeGeometry = selectedRoute.shape?.geometry else {
-      removeLayer(withId: geoJSONDataSourceIdentifier)
-      return
+    func addLayer(
+      withIdentifier identifier: String,
+      color: UIColor,
+      route: MapboxDirections.Route,
+      layerPosition: LayerPosition
+    ) {
+      guard let routeGeometry = route.shape?.geometry else {
+        return
+      }
+
+      // Create a GeoJSON data source.
+      var geoJSONSource = GeoJSONSource()
+      geoJSONSource.data = .geometry(routeGeometry)
+
+      let lineLayer = BikeStreetsStyles.style(
+        forLayer: identifier,
+        source: identifier,
+        lineColor: StyleColor(color),
+        lineWidth: .expression(
+          Exp(.interpolate) {
+            Exp(.linear)
+            Exp(.zoom)
+            14
+            6
+            18
+            12
+          }
+        )
+      )
+
+      // Add the source and style layer to the map style.
+      try! mapView.mapboxMap.style.addSource(geoJSONSource, id: identifier)
+      try! mapView.mapboxMap.style.addPersistentLayer(
+        lineLayer,
+        layerPosition: layerPosition
+      )
     }
 
-    // Create a GeoJSON data source.
-    var geoJSONSource = GeoJSONSource()
-    geoJSONSource.data = .geometry(routeGeometry)
+    [
+      geoJSONDataSourceIdentifier,
+      geoJSONDataSourceIdentifierOSRM
+    ].forEach(removeLayer(withId:))
 
-    let lineLayer = BikeStreetsStyles.style(
-      forLayer: geoJSONDataSourceIdentifier,
-      source: geoJSONDataSourceIdentifier,
-      lineColor: StyleColor(.vamosYellow),
-      lineWidth: .expression(
-        Exp(.interpolate) {
-          Exp(.linear)
-          Exp(.zoom)
-          14
-          6
-          18
-          12
-        }
-      )
-    )
-
-    // Add the source and style layer to the map style.
-    removeLayer(withId: geoJSONDataSourceIdentifier)
-    try! mapView.mapboxMap.style.addSource(geoJSONSource, id: geoJSONDataSourceIdentifier)
-    try! mapView.mapboxMap.style.addPersistentLayer(
-      lineLayer,
+    addLayer(
+      withIdentifier: geoJSONDataSourceIdentifier,
+      color: .vamosYellow,
+      route: combinedRoute.mapbox,
       layerPosition: .below(MapLayerSpec.allCases.first!.identifier)
     )
+
+    switch GlobalSettings.directionsPreviewConfiguration {
+    case .combined:
+      addLayer(
+        withIdentifier: geoJSONDataSourceIdentifierOSRM,
+        color: .magenta.withAlphaComponent(0.8),
+        route: combinedRoute.osrm,
+        layerPosition: .below(geoJSONDataSourceIdentifier)
+      )
+    case .mapbox:
+      // Mapbox route already added
+      break
+    }
   }
 
   // MARK: - State Handling
@@ -222,10 +243,15 @@ final class DefaultMapsViewController: MapsViewController {
       switch result {
       case .success(let result):
         DispatchQueue.main.async {
-          if let firstRoute = result.routes?.first {
+          if let osrmRoute = result.osrm.routes?.first,
+             let mapboxRoute = result.mapbox.routes?.first {
             // On initial state update, assume first route is selected.
             self.stateManager.state = .previewDirections(
-              preview: .init(request: request, response: result, selectedRoute: firstRoute)
+              preview: .init(
+                request: request,
+                response: result,
+                selectedRoute: .init(osrm: osrmRoute, mapbox: mapboxRoute)
+              )
             )
           } else {
             // TODO: Improve the state when a route is requested but returns no options.
@@ -345,7 +371,7 @@ extension DefaultMapsViewController: StateListener {
       // sheetNavigationController.sheetPresentationController?.selectedDetentIdentifier = UISheetPresentationController.Detent.small().identifier
       requestDirections(request: request)
     case .previewDirections(let preview):
-      updateMapAnnotations(isRouting: false, selectedRoute: preview.selectedRoute, potentialRoutes: preview.response.routes ?? [preview.selectedRoute])
+      updateMapAnnotations(combinedRoute: preview.selectedRoute)
     case .updateDestination(let preview):
       let searchViewController = SearchViewController(
         configuration: .newDestination,
@@ -377,11 +403,11 @@ extension DefaultMapsViewController: StateListener {
         })
       )
     case .routing(let routing):
-      switch liveRoutingConfiguration {
+      switch GlobalSettings.liveRoutingConfiguration {
       case .mapbox:
         // TODO: (@mattrob) This should be associated with the selected route not the `0` index.
         let indexedRouteResponse = IndexedRouteResponse(
-          routeResponse: routing.response,
+          routeResponse: routing.response.mapbox,
           routeIndex: 0
         )
 
@@ -427,7 +453,7 @@ extension DefaultMapsViewController: StateListener {
         }
 
         // Update route polyline display.
-        updateMapAnnotations(isRouting: true, selectedRoute: routing.selectedRoute, potentialRoutes: [])
+        updateMapAnnotations(combinedRoute: routing.selectedRoute)
       }
     case .routingFeedback(let feedback):
       // Can only present mail controller when sheets are dismissed.
@@ -622,7 +648,17 @@ extension DefaultMapsViewController: MapCameraStateListener {
 
       // TODO: Add handling for "possible routes" vs. just the selected route.
       // preview.response.routes.map(\.geometry.coordinates).flatMap { $0 }
-      let coordinates: [CLLocationCoordinate2D] = route.shape?.coordinates ?? []
+      let coordinates: [CLLocationCoordinate2D] = {
+        let mapboxCoordinates: [CLLocationCoordinate2D] = route.mapbox.shape?.coordinates ?? []
+
+        switch GlobalSettings.directionsPreviewConfiguration {
+        case .combined:
+          let osrmCoordinates = route.osrm.shape?.coordinates ?? []
+          return osrmCoordinates + mapboxCoordinates
+        case .mapbox:
+          return mapboxCoordinates
+        }
+      }()
 
       newState = mapView.viewport.makeOverviewViewportState(
         options: .init(

--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -182,10 +182,13 @@ extension DirectionPreviewViewController: RouteSelectable {
   func didStart(route: MapboxDirections.Route) {
     switch stateManager.state {
     case .previewDirections(let preview):
+      guard let osrmRoute = preview.response.routes?.first else {
+        fatalError("Unable to determine initial OSRM route")
+      }
       stateManager.state = .routing(routing: .init(
         request: preview.request,
         response: preview.response,
-        selectedRoute: route
+        selectedRoute: .init(osrm: osrmRoute, mapbox: route)
       ))
     default:
       fatalError("State must be preview directions when route is selected")


### PR DESCRIPTION
|Example 1|Example 2|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-01-05 at 10 16 56](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/d2a6cf7f-6b93-40fa-add8-4e38f88b55bc)|![Simulator Screenshot - iPhone 15 - 2024-01-05 at 10 17 42](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/332c1589-706a-43a7-99d4-55784b8a529c)|

Switch back to just Mapbox using:
```diff
--- a/bikestreets-ios/Managers/GlobalSettings.swift
+++ b/bikestreets-ios/Managers/GlobalSettings.swift
@@ -18,7 +18,7 @@ struct GlobalSettings {
     case combined
   }

-  static let directionsPreviewConfiguration: DirectionsPreviewConfiguration = .combined
+  static let directionsPreviewConfiguration: DirectionsPreviewConfiguration = .mapbox

   // MARK: -- Live Routing
```