### PR TITLE
Enhance custom live routing zoom and pitch

### DIFF
--- a/bikestreets-ios/Managers/CompassManager.swift
+++ b/bikestreets-ios/Managers/CompassManager.swift
@@ -23,6 +23,9 @@ final class MapCameraManager {
     /// Centered on the user, map orientation following direction of travel.
     case followUserHeading
     case followUserHeadingIdle
+    /// Centered on the user, harsher viewing anlge to look forward further.
+    case routing
+    case routingIdle
     /// Not oriented to anything. User could be free-scrolling the map.
     case showRoute(route: CombinedRoute)
     case showRouteIdle(route: CombinedRoute)
@@ -48,9 +51,9 @@ final class MapCameraManager {
       return "location.fill"
     case .followUserPositionIdle:
       return "location"
-    case .followUserHeading:
+    case .followUserHeading, .routing:
       return "location.north.line.fill"
-    case .followUserHeadingIdle:
+    case .followUserHeadingIdle, .routingIdle:
       return "location.north.line"
     case .showRoute:
       return "location.fill.viewfinder"
@@ -79,10 +82,13 @@ final class MapCameraManager {
       state = .followUserPositionIdle
     case .followUserHeading:
       state = .followUserHeadingIdle
+    case .routing:
+      state = .routingIdle
     case .showRoute(let route):
       state = .showRouteIdle(route: route)
     case .followUserPositionIdle,
         .followUserHeadingIdle,
+        .routingIdle,
         .showRouteIdle:
       // Already idle
       break
@@ -99,10 +105,13 @@ final class MapCameraManager {
       state = .followUserPosition
     case .followUserHeadingIdle:
       state = .followUserHeading
+    case .routingIdle:
+      state = .routing
     case .showRouteIdle(let route):
       state = .showRoute(route: route)
     case .followUserPosition,
         .followUserHeading,
+        .routing,
         .showRoute:
       // Already not idle
       break

--- a/bikestreets-ios/Managers/RouteRequester.swift
+++ b/bikestreets-ios/Managers/RouteRequester.swift
@@ -36,11 +36,13 @@ struct CombinedRouteResponse {
 
   /// An array of `Route` objects based on the choice ot use the OSRM or Mapbox backend.
   public var routes: [Route]? {
+    // Intentionally just select the first route, adjust in the
+    // future if desired.
     switch GlobalSettings.liveRoutingConfiguration {
     case .mapbox:
-      return mapbox.routes
+      return mapbox.routes?.first.map { [$0] }
     case .custom:
-      return osrm.routes
+      return osrm.routes?.first.map { [$0] }
     }
   }
 }

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -489,7 +489,11 @@ extension DefaultMapsViewController: StateListener {
           .updateOrigin(let preview),
           .updateDestination(let preview):
         return .showRoute(route: preview.selectedRoute)
-      case .routing: return .followUserHeading
+      case .routing:
+        switch GlobalSettings.liveRoutingConfiguration {
+        case .mapbox: return .followUserHeading
+        case .custom: return .routing
+        }
       }
     }()
   }
@@ -683,8 +687,26 @@ extension DefaultMapsViewController: MapCameraStateListener {
           pitch: 0
         )
       )
+    case .routing:
+      newState = mapView.viewport.makeFollowPuckViewportState(
+        options: FollowPuckViewportStateOptions(
+          padding: UIEdgeInsets(
+            // This ends up being the offset from the middle of the viewport.
+            top: (view.bounds.height - bottomInset) * 0.75,
+            left: 0,
+            bottom: bottomInset, 
+            right: 0
+          ),
+          // Higher is more zoomed in
+          zoom: 20,
+          bearing: .heading,
+          // Less is closer to the straight on view of 0°
+          pitch: 60
+        )
+      )
     case .followUserPositionIdle,
         .followUserHeadingIdle,
+        .routingIdle,
         .showRouteIdle:
       // Idle, no viewport transition
       newState = nil


### PR DESCRIPTION
- Limit the route possibilities to always show a single route. This was the case for Mapbox but not for the custom directions.
- Shift the user's position down in the viewport and increase the harshness of the viewing angle.

|Example 1|Example 2|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-01-05 at 13 18 30](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/28440016-1fc6-4aae-89c9-7dda28683fe8)|![Simulator Screenshot - iPhone 15 - 2024-01-05 at 13 18 49](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/984783f4-4887-428d-8f53-9f8d6af835a5)|