### PR TITLE
Use targetEnvironment(simulator) compiler flag

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -435,9 +435,11 @@ extension DefaultMapsViewController: StateListener {
           credentials: NavigationSettings.shared.directions.credentials,
           simulating: .onPoorGPS
         )
-        // these 2 lines allow the route simulation to run faster.
-        // navigationService.simulationMode = .always
-        // navigationService.simulationSpeedMultiplier = 5.0
+        #if targetEnvironment(simulator)
+          // these 2 lines allow the route simulation to run faster.
+          navigationService.simulationMode = .always
+          navigationService.simulationSpeedMultiplier = 5.0
+        #endif
         
         let navigationOptions = NavigationOptions(navigationService: navigationService)
         navigationViewController = NavigationViewController(


### PR DESCRIPTION
When running in simulator, using the compiler flag avoids need to comment/un-comment simulator speed code. 