### PR TITLE
Sentence case step names to handle sidewalk, alley, etc

### DIFF
--- a/bikestreets-ios/Managers/InstructionGenerator.swift
+++ b/bikestreets-ios/Managers/InstructionGenerator.swift
@@ -171,7 +171,7 @@ enum InstructionGenerator {
         if (name.isEmpty || stepInfo.isArrival), let instructionText {
           instructionComponent["text"] = instructionText
         } else {
-          instructionComponent["text"] = name
+          instructionComponent["text"] = name.capitalizedSentence
         }
       }
       
@@ -488,6 +488,14 @@ extension RouteResponse {
         }
       }
     }
+  }
+}
+
+extension String {
+  var capitalizedSentence: String {
+    let firstLetter = self.prefix(1).uppercased()
+    let remainingLetters = self.dropFirst().lowercased()
+    return firstLetter + remainingLetters
   }
 }
 


### PR DESCRIPTION
I would have just used .capitalize in Foundation, but that uppercases the first character of every word, and other undesired behavior like "38Th".

https://trello.com/c/qPad5Rjs/65-uppercase-the-first-character-of-step-names-for-rendering-in-banner-instructions