### PR TITLE
Adding location to background modes in info.plist. 

### DIFF
--- a/bikestreets-ios/Info.plist
+++ b/bikestreets-ios/Info.plist
@@ -22,6 +22,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>location</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Seems like we are already covered with project file settings for audio and location in background, but trying this out.

Audio is not currently working while app is in background.

https://docs.mapbox.com/ios/navigation/api/1.0.0/
"Users expect the SDK to continue to track the user’s location and deliver audible instructions even while a different application is visible or the device is locked. Go to the Signing & Capabilities tab. Under the Background Modes section, enable “Audio, AirPlay, and Picture in Picture” and “Location updates”. (Alternatively, add the audio and location values to the UIBackgroundModes array in the Info tab.)"