### PR TITLE
Correct ornament inset on button’d phones

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -521,8 +521,10 @@ extension DefaultMapsViewController: SizeTrackingListener {
     // Update map camera.
     syncCameraState(bottomInset: frame.height)
 
-    // Update Mapbox ornaments.
-    let mapboxOrnamentYInset = frame.height - 8
+    // Update Mapbox ornaments. Mapbox insets the ornaments by the safe
+    // area so include that in our ornament offset calculations.
+    let safeAreaBottomPadding = UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0
+    let mapboxOrnamentYInset = frame.height + 8 - safeAreaBottomPadding
     mapView.ornaments.options.logo.margins = .init(x: 8.0, y: mapboxOrnamentYInset)
     mapView.ornaments.options.compass.margins = .init(x: 8.0, y: mapboxOrnamentYInset)
   }


### PR DESCRIPTION
|iPhone 15|iPhone SE|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-02-09 at 14 42 12](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/5693f135-7f9d-433d-a87a-ba8248b3afb2)|![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-09 at 14 42 13](https://github.com/bikestreets/bikestreets-ios-denver/assets/5728070/5df57205-26c8-42ea-b40c-0cc95fd81469)|