### PR TITLE
When mapView.viewport transition fails, retry once

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -33,6 +33,7 @@ final class DefaultMapsViewController: MapsViewController {
   private let stateManager = StateManager()
   private let mapCameraManager = MapCameraManager()
   private let screenManager: ScreenManager
+  private var viewportTransitionFailureCount = 0
 
   /// Camera bottom inset based on the presented sheet height.
   private var cameraBottomInset: CGFloat {
@@ -738,6 +739,27 @@ extension DefaultMapsViewController: ViewportStatusObserver {
     to toStatus: MapboxMaps.ViewportStatus,
     reason: MapboxMaps.ViewportStatusChangeReason
   ) {
+    // on failure to transition, try one more time to transition to the attempted state
+    switch reason {
+    case .transitionFailed:
+      viewportTransitionFailureCount += 1
+      if viewportTransitionFailureCount <= 1 {
+        switch fromStatus {
+        case .transition(_, let state):
+          mapView.viewport.transition(to: state)
+          return
+        default:
+          break
+        }
+      } else {
+        // retry failed -> reset the counter and proceed
+        viewportTransitionFailureCount = 0
+      }
+    case .transitionSucceeded:
+      viewportTransitionFailureCount = 0
+    default: break
+    }
+
     switch toStatus {
     case .idle:
       mapCameraManager.toIdle()


### PR DESCRIPTION
Attempting to address an issue where transition fails after navigationVC is dismissed, which leaves map camera state idle instead of followUserPosition/followPuckViewportState

We don't really understand why the transition failure happens, and the retry doesn't seem to succeed on any retries (for any failures), so this just feels like it buys time until didChangeFrame gets called which calls syncCameraState and gets us back to following user position. The alternative is to just ignore failures, but that also feels wrong. Let's try this solution for now, but I don't consider this resolved.