### PR TITLE
Remove Mapbox route retrieval as a mode

### DIFF
--- a/bikestreets-ios/Managers/CompassManager.swift
+++ b/bikestreets-ios/Managers/CompassManager.swift
@@ -27,8 +27,8 @@ final class MapCameraManager {
     case routing
     case routingIdle
     /// Not oriented to anything. User could be free-scrolling the map.
-    case showRoute(route: CombinedRoute)
-    case showRouteIdle(route: CombinedRoute)
+    case showRoute(route: Route)
+    case showRouteIdle(route: Route)
   }
 
   var state: State = .showDenver {

--- a/bikestreets-ios/Managers/GlobalSettings.swift
+++ b/bikestreets-ios/Managers/GlobalSettings.swift
@@ -9,19 +9,6 @@ import Foundation
 
 struct GlobalSettings {
 
-  // MARK: -- Directions Preview
-
-  enum DirectionsPreviewConfiguration {
-    /// Show just the Mapbox Directions result on the directions preview screen.
-    case mapbox
-    /// Show just the OSRM result on the directions preview screen.
-    case osrm
-    /// Show both the OSRM and Mapbox result on the directions preview screen.
-    case combined
-  }
-
-  static let directionsPreviewConfiguration: DirectionsPreviewConfiguration = .osrm
-
   // MARK: -- Live Routing
 
   enum LiveRoutingConfiguration {

--- a/bikestreets-ios/Managers/RouteRequester.swift
+++ b/bikestreets-ios/Managers/RouteRequester.swift
@@ -28,43 +28,26 @@ enum InternalMapboxAPIMode {
   }
 }
 
-/// Combination of the generated OSRM and Mapbox routes.
-struct CombinedRoute {
-  let osrm: Route
-  let mapbox: Route
-
-  // MARK: -- Coordinates
-
-  var osrmCoordinates: [CLLocationCoordinate2D] {
-    osrm.shape?.coordinates ?? []
-  }
-
-  var mapboxCoordinates: [CLLocationCoordinate2D] {
-    mapbox.shape?.coordinates ?? []
+extension Route {
+  var coordinates: [CLLocationCoordinate2D] {
+    return shape?.coordinates ?? []
   }
 }
 
 /// Representation of the route response from the BikeStreets internal OSRM API
-/// and the external Mapbox API.
-struct CombinedRouteResponse {
+/// Wrapping RouteResponse so that we can control which routes are available to preview
+struct CustomRouteResponse {
   let osrm: RouteResponse
-  let mapbox: RouteResponse
 
-  /// An array of `Route` objects based on the choice to use the OSRM or Mapbox backend.
   public var routes: [Route]? {
     // Intentionally just select the first route, adjust in the
     // future if desired.
-    switch GlobalSettings.liveRoutingConfiguration {
-    case .mapbox:
-      return mapbox.routes?.first.map { [$0] }
-    case .custom:
-      return osrm.routes?.first.map { [$0] }
-    }
+    return osrm.routes?.first.map { [$0] }
   }
 }
 
 final class RouteRequester {
-  private static let mode = InternalMapboxAPIMode.mapMatching
+  private static let mapboxAPIMode = InternalMapboxAPIMode.mapMatching
 
   enum RequestError: Error {
     case emptyData
@@ -76,7 +59,7 @@ final class RouteRequester {
     startPoint: CLLocationCoordinate2D,
     destinationName: String,
     endPoint: CLLocationCoordinate2D,
-    completion: @escaping (Result<CombinedRouteResponse, Error>) -> Void
+    completion: @escaping (Result<CustomRouteResponse, Error>) -> Void
   ) {
     // BIKESTREETS DIRECTIONS
 
@@ -161,86 +144,90 @@ final class RouteRequester {
         //osrmResponse.printOSRMTextInstructions()
         //osrmResponse.printJSON()
         
-        // Request Mapbox route
-        //
-        // Copied from: https://docs.mapbox.com/ios/navigation/examples/custom-server/
-        let originalRouteCoordinates = osrmResponse.routes?[0].shape?.coordinates ?? []
-
-        var tolerance: Float = 0.000001
-        var simplifiedRouteCoordinates = originalRouteCoordinates
-        while simplifiedRouteCoordinates.count > mode.maximumCoordinates {
-          simplifiedRouteCoordinates = Simplify.simplify(originalRouteCoordinates, tolerance: tolerance, highQuality: true)
-          tolerance += 0.0000025
-        }
-
-        print("""
-
-        ROUTE SIMPLIFICATION
-        Before: \(originalRouteCoordinates.count)
-        After:  \(simplifiedRouteCoordinates.count)
-
-
-        """)
-
-        print("""
+        completion(.success(.init(osrm: osrmResponse)))
         
-        ==== MAPBOX ====
-        
-        """)
-        switch mode {
-        case .mapMatching:
-          //
-          // ❗️IMPORTANT❗️
-          // Use `Directions.calculateRoutes(matching:completionHandler:)` for navigating on a map matching response.
-          //
-          let matchOptions = NavigationMatchOptions(
-            coordinates: simplifiedRouteCoordinates,
-            profileIdentifier: .cycling
-          )
-          matchOptions.includesSpokenInstructions = true
-          matchOptions.includesVisualInstructions = true
-          matchOptions.waypoints.disableWaypointLegSeparation()
-
-          Directions.shared.calculateRoutes(matching: matchOptions) { _, mapboxResult in
-            switch mapboxResult {
-            case .failure(let error):
-              print(error.localizedDescription)
-            case .success(let mapboxResponse):
-              // Return parsed response
-              //mapboxResponse.printVoiceInstructions()
-              //mapboxResponse.printOSRMTextInstructions()
-              //mapboxResponse.printJSON()
-              
-              completion(.success(.init(osrm: osrmResponse, mapbox: mapboxResponse)))
-            }
-          }
-        case .directions:
-          let routeOptions = NavigationRouteOptions(
-            coordinates: simplifiedRouteCoordinates,
-            profileIdentifier: .cycling
-          )
-          routeOptions.includesSpokenInstructions = true
-          routeOptions.includesVisualInstructions = true
-          routeOptions.waypoints.disableWaypointLegSeparation()
-
-          Directions.shared.calculate(routeOptions) { _, mapboxResult in
-            switch mapboxResult {
-            case .failure(let error):
-              print(error.localizedDescription)
-            case .success(let mapboxResponse):
-              //mapboxResponse.printVoiceInstructions()
-              //mapboxResponse.printOSRMTextInstructions()
-              //mapboxResponse.printJSON()
-              completion(.success(.init(osrm: osrmResponse, mapbox: mapboxResponse)))
-            }
-          }
-        }
-
+        // For comparing Mapbox route/instructions to OSRM route/instructions
+        // requestMapboxDirections(osrmResponse: osrmResponse)
       } catch {
         completion(.failure(error))
       }
     }
     task.resume()
+  }
+  
+  static func requestMapboxDirections(osrmResponse: RouteResponse) -> Void {
+    // Request Mapbox route
+    //
+    // Copied from: https://docs.mapbox.com/ios/navigation/examples/custom-server/
+    let originalRouteCoordinates = osrmResponse.routes?[0].shape?.coordinates ?? []
+
+    var tolerance: Float = 0.000001
+    var simplifiedRouteCoordinates = originalRouteCoordinates
+    while simplifiedRouteCoordinates.count > mapboxAPIMode.maximumCoordinates {
+      simplifiedRouteCoordinates = Simplify.simplify(originalRouteCoordinates, tolerance: tolerance, highQuality: true)
+      tolerance += 0.0000025
+    }
+
+    print("""
+
+    ROUTE SIMPLIFICATION
+    Before: \(originalRouteCoordinates.count)
+    After:  \(simplifiedRouteCoordinates.count)
+
+
+    """)
+
+    print("""
+    
+    ==== MAPBOX ====
+    
+    """)
+    
+    switch mapboxAPIMode {
+    case .mapMatching:
+      //
+      // ❗️IMPORTANT❗️
+      // Use `Directions.calculateRoutes(matching:completionHandler:)` for navigating on a map matching response.
+      //
+      let matchOptions = NavigationMatchOptions(
+        coordinates: simplifiedRouteCoordinates,
+        profileIdentifier: .cycling
+      )
+      matchOptions.includesSpokenInstructions = true
+      matchOptions.includesVisualInstructions = true
+      matchOptions.waypoints.disableWaypointLegSeparation()
+
+      Directions.shared.calculateRoutes(matching: matchOptions) { _, mapboxResult in
+        switch mapboxResult {
+        case .failure(let error):
+          print(error.localizedDescription)
+        case .success(let mapboxResponse):
+          // Return parsed response
+          mapboxResponse.printVoiceInstructions()
+          mapboxResponse.printOSRMTextInstructions()
+          mapboxResponse.printJSON()
+        }
+      }
+    case .directions:
+      let routeOptions = NavigationRouteOptions(
+        coordinates: simplifiedRouteCoordinates,
+        profileIdentifier: .cycling
+      )
+      routeOptions.includesSpokenInstructions = true
+      routeOptions.includesVisualInstructions = true
+      routeOptions.waypoints.disableWaypointLegSeparation()
+
+      Directions.shared.calculate(routeOptions) { _, mapboxResult in
+        switch mapboxResult {
+        case .failure(let error):
+          print(error.localizedDescription)
+        case .success(let mapboxResponse):
+          mapboxResponse.printVoiceInstructions()
+          mapboxResponse.printOSRMTextInstructions()
+          mapboxResponse.printJSON()
+        }
+      }
+    }
   }
 }
 

--- a/bikestreets-ios/Managers/StateManager.swift
+++ b/bikestreets-ios/Managers/StateManager.swift
@@ -49,14 +49,14 @@ final class StateManager {
 
   struct DirectionsPreview {
     let request: RouteRequest
-    let response: CombinedRouteResponse
-    let selectedRoute: CombinedRoute
+    let response: CustomRouteResponse
+    let selectedRoute: Route
   }
 
   struct Routing {
     let request: RouteRequest
-    let response: CombinedRouteResponse
-    let selectedRoute: CombinedRoute
+    let response: CustomRouteResponse
+    let selectedRoute: Route
   }
 
   enum State {

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -145,7 +145,7 @@ final class DefaultMapsViewController: MapsViewController {
   // MARK: - Map Movement
 
   // TODO: Make this smarter using approach from https://docs.mapbox.com/ios/maps/examples/line-gradient/
-  private func updateMapAnnotations(combinedRoute: CombinedRoute?) {
+  private func updateMapAnnotations(route: MapboxDirections.Route?) {
     let geoJSONDataSourceIdentifier = "current-route"
     let geoJSONDataSourceIdentifierOSRM = "current-route-osrm"
 
@@ -199,37 +199,14 @@ final class DefaultMapsViewController: MapsViewController {
       geoJSONDataSourceIdentifierOSRM
     ].forEach(removeLayer(withId:))
 
-    guard let combinedRoute else { return }
+    guard let route else { return }
 
-    switch GlobalSettings.directionsPreviewConfiguration {
-    case .combined:
-      addLayer(
-        withIdentifier: geoJSONDataSourceIdentifier,
-        color: .vamosYellow,
-        route: combinedRoute.mapbox,
-        layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
-      )
-      addLayer(
-        withIdentifier: geoJSONDataSourceIdentifierOSRM,
-        color: .magenta.withAlphaComponent(0.8),
-        route: combinedRoute.osrm,
-        layerPosition: .below(geoJSONDataSourceIdentifier)
-      )
-    case .osrm:
-      addLayer(
-        withIdentifier: geoJSONDataSourceIdentifierOSRM,
-        color: .vamosYellow,
-        route: combinedRoute.osrm,
-        layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
-      )
-    case .mapbox:
-      addLayer(
-        withIdentifier: geoJSONDataSourceIdentifier,
-        color: .vamosYellow,
-        route: combinedRoute.mapbox,
-        layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
-      )
-    }
+    addLayer(
+      withIdentifier: geoJSONDataSourceIdentifierOSRM,
+      color: .vamosYellow,
+      route: route,
+      layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
+    )
   }
 
   // MARK: - State Handling
@@ -256,14 +233,13 @@ final class DefaultMapsViewController: MapsViewController {
       switch result {
       case .success(let result):
         DispatchQueue.main.async {
-          if let osrmRoute = result.osrm.routes?.first,
-             let mapboxRoute = result.mapbox.routes?.first {
+          if let osrmRoute = result.routes?.first {
             // On initial state update, assume first route is selected.
             self.stateManager.state = .previewDirections(
               preview: .init(
                 request: request,
                 response: result,
-                selectedRoute: .init(osrm: osrmRoute, mapbox: mapboxRoute)
+                selectedRoute: osrmRoute
               )
             )
           } else {
@@ -361,7 +337,7 @@ extension DefaultMapsViewController: StateListener {
       }
 
       // Clean any annotations.
-      updateMapAnnotations(combinedRoute: nil)
+      updateMapAnnotations(route: nil)
     case .searchDestination:
       let searchViewController = SearchViewController(
         configuration: .initialDestination,
@@ -384,7 +360,7 @@ extension DefaultMapsViewController: StateListener {
       // sheetNavigationController.sheetPresentationController?.selectedDetentIdentifier = UISheetPresentationController.Detent.small().identifier
       requestDirections(request: request)
     case .previewDirections(let preview):
-      updateMapAnnotations(combinedRoute: preview.selectedRoute)
+      updateMapAnnotations(route: preview.selectedRoute)
     case .updateDestination(let preview):
       let searchViewController = SearchViewController(
         configuration: .newDestination,
@@ -472,7 +448,7 @@ extension DefaultMapsViewController: StateListener {
         }
 
         // Update route polyline display.
-        updateMapAnnotations(combinedRoute: routing.selectedRoute)
+        updateMapAnnotations(route: routing.selectedRoute)
       }
     case .routingFeedback(let feedback):
       // Can only present mail controller when sheets are dismissed.
@@ -674,14 +650,7 @@ extension DefaultMapsViewController: MapCameraStateListener {
       // TODO: Add handling for "possible routes" vs. just the selected route.
       // preview.response.routes.map(\.geometry.coordinates).flatMap { $0 }
       let coordinates: [CLLocationCoordinate2D] = {
-        switch GlobalSettings.directionsPreviewConfiguration {
-        case .combined:
-          return route.osrmCoordinates + route.mapboxCoordinates
-        case .osrm:
-          return route.osrmCoordinates
-        case .mapbox:
-          return route.mapboxCoordinates
-        }
+        return route.coordinates
       }()
 
       newState = mapView.viewport.makeOverviewViewportState(

--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -188,7 +188,7 @@ extension DirectionPreviewViewController: RouteSelectable {
       stateManager.state = .routing(routing: .init(
         request: preview.request,
         response: preview.response,
-        selectedRoute: .init(osrm: osrmRoute, mapbox: route)
+        selectedRoute: osrmRoute
       ))
     default:
       fatalError("State must be preview directions when route is selected")


### PR DESCRIPTION
- Remove DirectionsPreviewConfiguration, CombinedRoute
- Rename CombinedRouteResponse to CustomRouteResponse. Keep the wrapper so that we can control which routes are available without needing an extension that puts an .availableRoutes property as a sibling property to RouteResponse.routes, which would be confusing.
- Remove Mapbox route retrieval from main code path in RouteRequester.getOSMRDirections
- Keep Mapbox remote route retrieval available as a function in RouteRequester so that it can be used for debugging instructions, etc.