### PR TITLE
Show multiple routes on Directions Preview. Allow for selection of any available route.

### DIFF
--- a/bikestreets-ios/Managers/CompassManager.swift
+++ b/bikestreets-ios/Managers/CompassManager.swift
@@ -27,8 +27,8 @@ final class MapCameraManager {
     case routing
     case routingIdle
     /// Not oriented to anything. User could be free-scrolling the map.
-    case showRoute(route: Route)
-    case showRouteIdle(route: Route)
+    case showRoute(routes: [Route])
+    case showRouteIdle(routes: [Route])
   }
 
   var state: State = .showDenver {
@@ -84,8 +84,8 @@ final class MapCameraManager {
       state = .followUserHeadingIdle
     case .routing:
       state = .routingIdle
-    case .showRoute(let route):
-      state = .showRouteIdle(route: route)
+    case .showRoute(let routes):
+      state = .showRouteIdle(routes: routes)
     case .followUserPositionIdle,
         .followUserHeadingIdle,
         .routingIdle,
@@ -107,8 +107,8 @@ final class MapCameraManager {
       state = .followUserHeading
     case .routingIdle:
       state = .routing
-    case .showRouteIdle(let route):
-      state = .showRoute(route: route)
+    case .showRouteIdle(let routes):
+      state = .showRoute(routes: routes)
     case .followUserPosition,
         .followUserHeading,
         .routing,

--- a/bikestreets-ios/Managers/RouteRequester.swift
+++ b/bikestreets-ios/Managers/RouteRequester.swift
@@ -40,9 +40,7 @@ struct CustomRouteResponse {
   let osrm: RouteResponse
 
   public var routes: [Route]? {
-    // Intentionally just select the first route, adjust in the
-    // future if desired.
-    return osrm.routes?.first.map { [$0] }
+    return osrm.routes
   }
 }
 

--- a/bikestreets-ios/Managers/StateManager.swift
+++ b/bikestreets-ios/Managers/StateManager.swift
@@ -50,13 +50,14 @@ final class StateManager {
   struct DirectionsPreview {
     let request: RouteRequest
     let response: CustomRouteResponse
-    let selectedRoute: Route
+    let routes: [Route]
   }
 
   struct Routing {
     let request: RouteRequest
     let response: CustomRouteResponse
     let selectedRoute: Route
+    let selectedRouteIndex: Int
   }
 
   enum State {

--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -145,7 +145,7 @@ final class DefaultMapsViewController: MapsViewController {
   // MARK: - Map Movement
 
   // TODO: Make this smarter using approach from https://docs.mapbox.com/ios/maps/examples/line-gradient/
-  private func updateMapAnnotations(route: MapboxDirections.Route?) {
+  private func updateMapAnnotations(routes: [MapboxDirections.Route]?) {
     let geoJSONDataSourceIdentifier = "current-route"
     let geoJSONDataSourceIdentifierOSRM = "current-route-osrm"
 
@@ -194,19 +194,22 @@ final class DefaultMapsViewController: MapsViewController {
       )
     }
 
-    [
-      geoJSONDataSourceIdentifier,
-      geoJSONDataSourceIdentifierOSRM
-    ].forEach(removeLayer(withId:))
+    var layerIdsToRemove: [String] = [geoJSONDataSourceIdentifier]
+    layerIdsToRemove.append(contentsOf: mapView.mapboxMap.style.allLayerIdentifiers
+                              .map { $0.id }
+                              .filter { $0.hasPrefix(geoJSONDataSourceIdentifierOSRM) }
+                            )
+    layerIdsToRemove.forEach(removeLayer(withId:))
 
-    guard let route else { return }
-
-    addLayer(
-      withIdentifier: geoJSONDataSourceIdentifierOSRM,
-      color: .vamosYellow,
-      route: route,
-      layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
-    )
+    guard let routes else { return }
+    for (routeIndex, route) in routes.enumerated() {
+      addLayer(
+        withIdentifier: "\(geoJSONDataSourceIdentifierOSRM)-\(routeIndex)",
+        color: .vamosYellow,
+        route: route,
+        layerPosition: .below(MapLayerSpec.bottomLayerIdentifier)
+      )
+    }
   }
 
   // MARK: - State Handling
@@ -233,13 +236,13 @@ final class DefaultMapsViewController: MapsViewController {
       switch result {
       case .success(let result):
         DispatchQueue.main.async {
-          if let osrmRoute = result.routes?.first {
+          if let previewRoutes = result.routes {
             // On initial state update, assume first route is selected.
             self.stateManager.state = .previewDirections(
               preview: .init(
                 request: request,
                 response: result,
-                selectedRoute: osrmRoute
+                routes: previewRoutes
               )
             )
           } else {
@@ -337,7 +340,7 @@ extension DefaultMapsViewController: StateListener {
       }
 
       // Clean any annotations.
-      updateMapAnnotations(route: nil)
+      updateMapAnnotations(routes: nil)
     case .searchDestination:
       let searchViewController = SearchViewController(
         configuration: .initialDestination,
@@ -360,7 +363,7 @@ extension DefaultMapsViewController: StateListener {
       // sheetNavigationController.sheetPresentationController?.selectedDetentIdentifier = UISheetPresentationController.Detent.small().identifier
       requestDirections(request: request)
     case .previewDirections(let preview):
-      updateMapAnnotations(route: preview.selectedRoute)
+      updateMapAnnotations(routes: preview.routes)
     case .updateDestination(let preview):
       let searchViewController = SearchViewController(
         configuration: .newDestination,
@@ -394,10 +397,9 @@ extension DefaultMapsViewController: StateListener {
     case .routing(let routing):
       switch GlobalSettings.liveRoutingConfiguration {
       case .mapbox:
-        // TODO: (@mattrob) This should be associated with the selected route not the `0` index.
         let indexedRouteResponse = IndexedRouteResponse(
           routeResponse: routing.response.osrm,
-          routeIndex: 0
+          routeIndex: routing.selectedRouteIndex
         )
 
         // Intentionally choose to NOT request any alternative routes since this,
@@ -448,7 +450,7 @@ extension DefaultMapsViewController: StateListener {
         }
 
         // Update route polyline display.
-        updateMapAnnotations(route: routing.selectedRoute)
+        updateMapAnnotations(routes: [routing.selectedRoute])
       }
     case .routingFeedback(let feedback):
       // Can only present mail controller when sheets are dismissed.
@@ -473,7 +475,7 @@ extension DefaultMapsViewController: StateListener {
       case .previewDirections(let preview),
           .updateOrigin(let preview),
           .updateDestination(let preview):
-        return .showRoute(route: preview.selectedRoute)
+        return .showRoute(routes: preview.routes)
       case .routing:
         switch GlobalSettings.liveRoutingConfiguration {
         case .mapbox: return .followUserHeading
@@ -643,14 +645,12 @@ extension DefaultMapsViewController: MapCameraStateListener {
           pitch: 0
         )
       )
-    case .showRoute(let route):
+    case .showRoute(let routes):
       // Zoom to show a single route or all routes.
       let cameraTopInset: CGFloat = self.view.safeAreaInsets.top
 
-      // TODO: Add handling for "possible routes" vs. just the selected route.
-      // preview.response.routes.map(\.geometry.coordinates).flatMap { $0 }
       let coordinates: [CLLocationCoordinate2D] = {
-        return route.coordinates
+        return routes.flatMap { $0.coordinates }
       }()
 
       newState = mapView.viewport.makeOverviewViewportState(

--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -175,20 +175,21 @@ extension DirectionPreviewViewController: RoutePlaceRowViewDelegate {
 // MARK: - RouteSelectable
 
 extension DirectionPreviewViewController: RouteSelectable {
-  func didSelect(route: MapboxDirections.Route) {
+  func didSelect(routeIndex: Int) {
     // TODO: Add route selection support.
   }
 
-  func didStart(route: MapboxDirections.Route) {
+  func didStart(routeIndex: Int) {
     switch stateManager.state {
     case .previewDirections(let preview):
-      guard let osrmRoute = preview.response.routes?.first else {
-        fatalError("Unable to determine initial OSRM route")
+      guard let routes = preview.response.routes else {
+        fatalError("Unable to determine initial OSRM routes")
       }
       stateManager.state = .routing(routing: .init(
         request: preview.request,
         response: preview.response,
-        selectedRoute: osrmRoute
+        selectedRoute: routes[routeIndex],
+        selectedRouteIndex: routeIndex
       ))
     default:
       fatalError("State must be preview directions when route is selected")

--- a/bikestreets-ios/Search/Views/PossibleRoutesView.swift
+++ b/bikestreets-ios/Search/Views/PossibleRoutesView.swift
@@ -10,8 +10,8 @@ import MapboxDirections
 import UIKit
 
 protocol RouteSelectable: AnyObject {
-  func didSelect(route: MapboxDirections.Route)
-  func didStart(route: MapboxDirections.Route)
+  func didSelect(routeIndex: Int)
+  func didStart(routeIndex: Int)
 }
 
 final class PossibleRoutesView: UIStackView {
@@ -126,12 +126,12 @@ final class PossibleRoutesView: UIStackView {
     guard let routeIndex = recognizer.view?.tag else {
       return
     }
-    delegate?.didSelect(route: routes[routeIndex])
+    delegate?.didSelect(routeIndex: routeIndex)
   }
 
   @objc
   private func didTapRouteGo(sender: UIButton) {
     let routeIndex = sender.tag
-    delegate?.didStart(route: routes[routeIndex])
+    delegate?.didStart(routeIndex: routeIndex)
   }
 }


### PR DESCRIPTION
- Modify updateMapAnnotations to draw and remove multiple route layers
- DefaultMapsViewController unions all route coordinates when showing route in syncCameraState to ensure all possible routes are visible
- Add selectedRouteIndex to Routing struct, as it's easier to handle select/start of a route by index, since it's required for IndexedRouteResponse
- Modfy DirectionsPreview struct to support multiple routes
- Remove assumptions across preview/routing code that assume selecting first route in response