### PR TITLE
Remove debug sheet that appears on shake. 

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -874,23 +874,6 @@ extension DefaultMapsViewController: SheetManagerDelegate {
   }
 }
 
-// MARK: -- DEBUG
-
-extension DefaultMapsViewController {
-  override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-    /// Intentionally avoid showing the debug TVC when routing. Having the phone
-    /// on the handlebars generates lots of shakes that cause the app to crash.
-    if case .routing = stateManager.state {
-      return
-    }
-
-    if motion == .motionShake {
-      let files = try! DebugLogHandler().files()
-      sheetManager.present(DebugTableViewController(entries: files), animated: true)
-    }
-  }
-}
-
 // MARK: -- CLLocationManagerDelegate
 
 extension DefaultMapsViewController: CLLocationManagerDelegate {


### PR DESCRIPTION
Previously appeared when phone was shaken but not routing.