### PR TITLE
Allow requestingRoutes to be a valid (but ignored) state when tapping…

### DIFF
--- a/bikestreets-ios/Search/DirectionPreviewViewController.swift
+++ b/bikestreets-ios/Search/DirectionPreviewViewController.swift
@@ -170,7 +170,7 @@ extension DirectionPreviewViewController: RoutePlaceRowViewDelegate {
     switch stateManager.state {
     case .previewDirections(let preview):
       stateManager.state = .updateOrigin(preview: preview)
-    case .updateOrigin:
+    case .updateOrigin, .requestingRoutes:
       break
     default:
       fatalError("Unexpected state")
@@ -182,7 +182,7 @@ extension DirectionPreviewViewController: RoutePlaceRowViewDelegate {
     switch stateManager.state {
     case .previewDirections(let preview):
       stateManager.state = .updateDestination(preview: preview)
-    case .updateDestination:
+    case .updateDestination, .requestingRoutes:
       break
     default:
       fatalError("Unexpected state")


### PR DESCRIPTION
… on origin/destination update.

Some routes take a while to request and parse. This is the simplest possible fix, but ignore the tap on the rendered start/end point links on directions preview while still in .requestingRoutes state. A better fix would involve some UX to show progress indicator or something along those lines.