### PR TITLE
Update light/dark map styles for all map views

### DIFF
--- a/bikestreets-ios/Map/DefaultMapsViewController.swift
+++ b/bikestreets-ios/Map/DefaultMapsViewController.swift
@@ -570,14 +570,17 @@ extension DefaultMapsViewController: StateListener {
           navigationService.simulationSpeedMultiplier = 1.0
         #endif
         
-        let navigationOptions = NavigationOptions(navigationService: navigationService)
+        let navigationOptions = NavigationOptions(styles: [VamosDayStyle(), VamosNightStyle()], navigationService: navigationService)
         navigationViewController = NavigationViewController(
           for: indexedRouteResponse,
           navigationOptions: navigationOptions
         )
+        // usesNightStyleInDarkMode needs to be set before .showsReportFeedback/.showsEndOfRouteFeedback functions are called,
+        // else .night style won't be loaded correctly due to ordering of loading logic in NavigationViewController
+        navigationViewController?.usesNightStyleInDarkMode = true
         navigationViewController?.modalPresentationStyle = .fullScreen
         navigationViewController?.delegate = self
-        /// Disable "Report Problem" sheet that shows while navigating.
+        // Disable "Report Problem" sheet that shows while navigating.
         navigationViewController?.showsReportFeedback = false
         navigationViewController?.showsEndOfRouteFeedback = false
 

--- a/bikestreets-ios/Map/MapsViewController.swift
+++ b/bikestreets-ios/Map/MapsViewController.swift
@@ -54,6 +54,8 @@ class MapsViewController: UIViewController {
     )
     mapView.mapboxMap.setCamera(to: cameraOptions)
 
+    // Load appropriate map style based on light/dark mode
+    updateMapStyle()
     // Hide Mapbox 'i' button
     mapView.ornaments.options.attributionButton.margins = .init(x: -10000, y: 0)
     // Move Mapbox compass
@@ -130,9 +132,10 @@ class MapsViewController: UIViewController {
   // MARK: -- Layer Placement
   
   internal var belowRoadLabelLayer: LayerPosition? {
-    let id = "road-label"
-    let roadLabelId =  mapView.mapboxMap.style.styleManager.styleLayerExists(forLayerId: id) ? id : nil
-    
+    // Either "road-label" or "road-label-simple" could be used as the road label layer
+    let roadLabelPrefix = "road-label"
+    let roadLabelLayer = mapView.mapboxMap.style.styleManager.getStyleLayers().filter({ $0.id.hasPrefix(roadLabelPrefix) }).first ?? nil
+    let roadLabelId =  roadLabelLayer?.id ?? nil
     guard let roadLabelId else { return nil }
     return .below(roadLabelId)
   }
@@ -151,9 +154,9 @@ extension MapsViewController {
 
   private var currentMapboxStyle: StyleURI {
     if traitCollection.userInterfaceStyle == .dark {
-      return .dark
+      return .vamosStreetsDark
     } else {
-      return .vamosStreets
+      return .vamosStreetsLight
     }
   }
 

--- a/bikestreets-ios/Map/MapsViewController.swift
+++ b/bikestreets-ios/Map/MapsViewController.swift
@@ -134,7 +134,7 @@ class MapsViewController: UIViewController {
   internal var belowRoadLabelLayer: LayerPosition? {
     // Either "road-label" or "road-label-simple" could be used as the road label layer
     let roadLabelPrefix = "road-label"
-    let roadLabelLayer = mapView.mapboxMap.style.styleManager.getStyleLayers().filter({ $0.id.hasPrefix(roadLabelPrefix) }).first ?? nil
+    let roadLabelLayer = mapView.mapboxMap.style.styleManager.getStyleLayers().first(where: { $0.id.hasPrefix(roadLabelPrefix) })
     let roadLabelId =  roadLabelLayer?.id ?? nil
     guard let roadLabelId else { return nil }
     return .below(roadLabelId)

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -31,7 +31,7 @@ extension StyleURI {
 /// Day style used by NavigationViewController for light mode and day hours.
 /// Will be used in day hours with dark mode enabled unless NavigationViewController.usesNightStyleInDarkMode is true
 /// Additional UIView.appearance modifications can be made in apply(). See CustomStyleUIElements class in Mapbox's Navigation-Examples project for extensive examples.
-class VamosDayStyle: DayStyle {
+final class VamosDayStyle: DayStyle {
   required init() {
     super.init()
     mapStyleURL = URL(string: StyleURI.vamosStreetsLight.rawValue)!

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MapboxMaps
+import MapboxNavigation
 import UIKit
 
 // MARK: - Map Styles
@@ -17,6 +18,43 @@ extension StyleURI {
   static let vamosStreets = StyleURI(
     rawValue: "mapbox://styles/mkbitbucket/clqgwgexa007s01rjhxpwcpaw"
   )!
+  
+  static let vamosStreetsLight = StyleURI(
+    rawValue: "mapbox://styles/mkbitbucket/cltt4qtxa01lx01o80ujx0dvl"
+  )!
+  
+  static let vamosStreetsDark = StyleURI(
+    rawValue: "mapbox://styles/mkbitbucket/cltt4wy2g01l801oic0udggc7"
+  )!
+}
+
+/// Day style used by NavigationViewController for light mode and day hours.
+/// Will be used in day hours with dark mode enabled unless NavigationViewController.usesNightStyleInDarkMode is true
+/// Additional UIView.appearance modifications can be made in apply(). See CustomStyleUIElements class in Mapbox's Navigation-Examples project for extensive examples.
+class VamosDayStyle: DayStyle {
+  required init() {
+    super.init()
+    mapStyleURL = URL(string: StyleURI.vamosStreetsLight.rawValue)!
+    styleType = .day
+  }
+  
+  override func apply() {
+    super.apply()
+  }
+}
+
+/// Night style used by NavigationViewController for dark mode, night hours, and tunnels.
+/// Additional UIView.appearance modifications can be made in apply(). See CustomStyleUIElements class in Mapbox's Navigation-Examples project for extensive examples.
+class VamosNightStyle: NightStyle {
+  required init() {
+    super.init()
+    mapStyleURL = URL(string: StyleURI.vamosStreetsDark.rawValue)!
+    styleType = .night
+  }
+  
+  override func apply() {
+    super.apply()
+  }
 }
 
 // MARK: -

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -38,9 +38,6 @@ class VamosDayStyle: DayStyle {
     styleType = .day
   }
   
-  override func apply() {
-    super.apply()
-  }
 }
 
 /// Night style used by NavigationViewController for dark mode, night hours, and tunnels.

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -42,7 +42,7 @@ final class VamosDayStyle: DayStyle {
 
 /// Night style used by NavigationViewController for dark mode, night hours, and tunnels.
 /// Additional UIView.appearance modifications can be made in apply(). See CustomStyleUIElements class in Mapbox's Navigation-Examples project for extensive examples.
-class VamosNightStyle: NightStyle {
+final class VamosNightStyle: NightStyle {
   required init() {
     super.init()
     mapStyleURL = URL(string: StyleURI.vamosStreetsDark.rawValue)!

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -49,9 +49,6 @@ class VamosNightStyle: NightStyle {
     styleType = .night
   }
   
-  override func apply() {
-    super.apply()
-  }
 }
 
 // MARK: -

--- a/bikestreets-ios/Styles/BikeStreetsStyles.swift
+++ b/bikestreets-ios/Styles/BikeStreetsStyles.swift
@@ -15,6 +15,7 @@ import UIKit
 extension StyleURI {
   /// Avi's custom map style designed to minimize highway prevalence.
   /// This style started out as `.streets` with customizations.
+  /// Testing the new Light and Dark styles below. Leaving this here for debug comparisons during testing period.
   static let vamosStreets = StyleURI(
     rawValue: "mapbox://styles/mkbitbucket/clqgwgexa007s01rjhxpwcpaw"
   )!


### PR DESCRIPTION
- Add light/dark map styles to minimalist styles Avi recently created
- Update map styles when MapViewController loads, not just when traitCollection changes
- Create .day and .night styles using new light/dark map styles so that they can be passed to NavigationViewController in live routing
- Update road label layer logic so that we find the first layer with 'road-label' as a prefix instead of an exact match. 'road-label-simple' can also be used, as in these new styles.
- Set navigationViewController.userNightStyleInDarkMode to true and set it early in lifecycle as per code comment